### PR TITLE
Break method coderef creation into its own sub

### DIFF
--- a/lib/WWW/eNom/Role/Commands.pm
+++ b/lib/WWW/eNom/Role/Commands.pm
@@ -87,12 +87,18 @@ my @commands = qw(
     XXX_GetMemberId XXX_RemoveMemberId XXX_SetMemberId
 );
 
-my $ua = HTTP::Tiny->new;
-for my $command (@commands) {
-    fresh $command => sub {
+has _ua => (is => 'lazy', builder => sub { HTTP::Tiny->new });
+
+fresh $_ => __PACKAGE__->_make_command_coderef($_)
+    for @commands;
+
+sub _make_command_coderef {
+    my ($thing, $command) = @_;
+
+    return sub {
         my ($self, @opts) = @_;
         my $uri = $self->_make_query_string($command, @opts);
-        my $response = $ua->get($uri)->{content};
+        my $response = $self->_ua->get($uri)->{content};
         my $response_type = $self->response_type;
         if ( $response_type eq "xml_simple" ) {
             $response = XMLin($response);


### PR DESCRIPTION
...to allow us to more easily extend this package with certain
additional commands.

By the same token, change stick $ua into an attribute of its own.